### PR TITLE
fixed json-loading empty payload

### DIFF
--- a/cbpro/websocket.py
+++ b/cbpro/websocket.py
@@ -80,7 +80,8 @@ class WebsocketStream(object):
     def receive(self) -> dict:
         if self.connected:
             payload = self.connection.recv()
-            return json.loads(payload)
+            if payload:
+                return json.loads(payload)
         return dict()
 
     def ping(self) -> None:


### PR DESCRIPTION
Hi,
I really like your rewrite of the original client.


I found, when stopping a `WebsocketClient` instance, I sometimes got a json error:

```
Exception in thread Thread-1:
Traceback (most recent call last):
  File "...\lib\threading.py", line 954, in _bootstrap_inner
    self.run()
  File "...\lib\threading.py", line 892, in run
    self._target(*self._args, **self._kwargs)
  File "...\lib\site-packages\cbpro\websocket.py", line 153, in start
    self.listen()
  File "...\lib\site-packages\cbpro\websocket.py", line 144, in listen
    message = self.stream.receive()
  File "...\erp\lib\site-packages\cbpro\websocket.py", line 83, in receive
    return json.loads(payload)
  File "...\lib\json\__init__.py", line 346, in loads
    return _default_decoder.decode(s)
  File "...\lib\json\decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "...\lib\json\decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

So I modified the `receive` method of `WebsocketStream` to check `payload` before calling json.loads on it.
This fixed it for me. Not entirely sure though if this simple check is a good idea.